### PR TITLE
tests: install bpf module when running make check-bpf

### DIFF
--- a/tests/automake.mk
+++ b/tests/automake.mk
@@ -274,6 +274,7 @@ check-system-userspace: all
 	"$$@" || (test X'$(RECHECK)' = Xyes && "$$@" --recheck)
 
 check-bpf: all
+	$(MAKE) install
 	set $(SHELL) '$(SYSTEM_BPF_TESTSUITE)' -C tests  AUTOTEST_PATH='$(AUTOTEST_PATH)' $(TESTSUITEFLAGS) -j1; \
 	"$$@" || (test X'$(RECHECK)' = Xyes && "$$@" --recheck)
 


### PR DESCRIPTION
This commit update datapath.o to the latest one before running the test.
This is how `make check-kmod` does.

Signed-off-by: Yi-Hung Wei <yihung.wei@gmail.com>