### PR TITLE
Rfc pr3: make OVN test case passed

### DIFF
--- a/bpf/lookup.h
+++ b/bpf/lookup.h
@@ -52,8 +52,8 @@ static inline void ovs_execute_actions(struct __sk_buff *skb,
                action->u.userspace.nlattr_len, ovs_cb_get_ifindex(skb));
         break;
     case OVS_ACTION_ATTR_SET:
-        printt("set action, remote ipv4 = %x, is_set = %d\n",
-               action->u.tunnel.remote_ipv4, action->is_set);
+        printt("set action, is_set_tunnel = %d\n",
+               action->is_set_tunnel);
         break;
     case OVS_ACTION_ATTR_PUSH_VLAN:
         printt("vlan push tci %d\n", action->u.push_vlan.vlan_tci);

--- a/bpf/odp-bpf.h
+++ b/bpf/odp-bpf.h
@@ -228,7 +228,7 @@ struct ovs_action_userspace {
 
 struct bpf_action {
     enum ovs_action_attr type;  /* action type */
-    uint32_t is_set;
+    uint32_t is_set_tunnel; /* to distinguish between SET (tunnel) and SET_MASKED (fields) */
     union {
         struct ovs_action_output out;   /* OVS_ACTION_ATTR_OUTPUT: 8B */
         struct ovs_action_trunc trunc;  /* OVS_ACTION_ATTR_TRUNC: 4B */

--- a/lib/dpif-bpf-odp.c
+++ b/lib/dpif-bpf-odp.c
@@ -590,8 +590,8 @@ odp_key_to_bpf_flow_key(const struct nlattr *nla, size_t nla_len,
             ovs_be16 tci = nl_attr_get_be16(a);
             struct vlan_tag_t *vlan = inner ? &key->headers.cvlan
                                             : &key->headers.vlan;
-            vlan->tci = htons(tci);
-            key->headers.vlan.tci = htons(tci);
+            vlan->tci = ntohs(tci);
+            key->headers.vlan.tci = ntohs(tci);
             /* etherType is set below in OVS_KEY_ATTR_ETHERTYPE. */
             key->headers.valid |= VLAN_VALID;
             break;

--- a/lib/dpif-bpf-odp.c
+++ b/lib/dpif-bpf-odp.c
@@ -174,15 +174,20 @@ odp_action_to_bpf_action(const struct nlattr *src, struct bpf_action *dst)
         dst->u.hash = *hash_act;
         break;
     }
-    case OVS_ACTION_ATTR_SET: {
+    case OVS_ACTION_ATTR_SET:
+    case OVS_ACTION_ATTR_SET_MASKED: {
         const struct nlattr *a;
+
+        dst->is_set_tunnel = 0;
         a = nl_attr_get(src);
+        dst->u.mset.key_type = nl_attr_type(a);
 
         switch (nl_attr_type(a)) {
         case OVS_KEY_ATTR_TUNNEL: {
             enum odp_key_fitness ret;
             struct flow_tnl_t tunnel;
 
+            dst->is_set_tunnel = 1;
             tunnel.tun_id = 0;
             ret = odp_tun_to_bpf_tun(nl_attr_get(a), nl_attr_get_size(a),
                                      &tunnel);
@@ -207,20 +212,6 @@ odp_action_to_bpf_action(const struct nlattr *src, struct bpf_action *dst)
             }
             break;
         }
-        default:
-            VLOG_INFO("%s: set %d is not supported", __func__,
-                      nl_attr_type(a));
-            return EOPNOTSUPP;
-        }
-        break;
-    }
-    case OVS_ACTION_ATTR_SET_MASKED: {
-        const struct nlattr *a;
-        a = nl_attr_get(src);
-
-        dst->u.mset.key_type = nl_attr_type(a);
-
-        switch (nl_attr_type(a)) {
         case OVS_KEY_ATTR_ETHERNET: {
             struct ovs_key_ethernet *ether;
 
@@ -240,11 +231,10 @@ odp_action_to_bpf_action(const struct nlattr *src, struct bpf_action *dst)
             break;
         }
         default:
-            VLOG_INFO("%s: set_mask %d is not supported", __func__,
+            VLOG_INFO("%s: set/set_mask %d is not supported", __func__,
                       nl_attr_type(a));
             return EOPNOTSUPP;
         }
-        dst->is_set = 1;
         break;
     }
     case OVS_ACTION_ATTR_TRUNC: {


### PR DESCRIPTION
with some fixex:
```
  1: datapath - basic BPF commands                   ok
  2: datapath - ping between two ports               ok
  3: datapath - http between two ports               ok
  4: datapath - ping between two ports on vlan       ok
  5: datapath - ping between two ports on cvlan      ok
  6: datapath - ping6 between two ports              ok
  7: datapath - ping6 between two ports on vlan      ok
  8: datapath - ping6 between two ports on cvlan     ok
  9: datapath - ping over bond                       skipped (system-bpf-traffic.at:210)
 10: datapath - ping over vxlan tunnel               ok
 11: datapath - ping over vxlan6 tunnel              ok
 12: datapath - ping over gre tunnel                 ok
 13: datapath - ping over geneve tunnel              ok
 14: datapath - ping over geneve6 tunnel             ok
 15: datapath - clone action                         FAILED (system-bpf-traffic.at:445)
 16: datapath - mpls actions                         FAILED (system-bpf-traffic.at:484)
 19: ovn -- 1 LR connects 2 LSes                     ok

```