### PR TITLE
refactor parser and enable XDP parsing

### DIFF
--- a/bpf/automake.mk
+++ b/bpf/automake.mk
@@ -10,7 +10,8 @@ bpf_headers = \
 	bpf/lookup.h \
 	bpf/action.h \
 	bpf/generated_headers.h \
-	bpf/xdp.h
+	bpf/xdp.h \
+	bpf/parser_common.h
 bpf_extra = \
 	bpf/ovs-proto.p4
 

--- a/bpf/generated_headers.h
+++ b/bpf/generated_headers.h
@@ -172,8 +172,8 @@ struct ebpf_headers_t {
         struct icmp_t icmp;
         struct icmpv6_t icmpv6;
     };
-    struct vlan_tag_t vlan;
-    struct vlan_tag_t cvlan;
+    struct vlan_tag_t vlan;  /* outer */
+    struct vlan_tag_t cvlan; /* inner */
 };
 struct ebpf_metadata_t {
     struct pkt_metadata_t md;

--- a/bpf/parser.h
+++ b/bpf/parser.h
@@ -28,262 +28,55 @@
 #include <linux/udp.h>
 #include <linux/icmp.h>
 
-#define TCP_FLAGS_BE16(tp) (*(__be16 *)&tcp_flag_word(tp) & bpf_htons(0x0FFF))
+#define OVS_LOAD_BYTES(xdp, offset, dst, len) \
+        bpf_skb_load_bytes(xdp, offset, dst, len)
+#define OVS_SK_BUFF __sk_buff
+#define PARSE_DATA tc_parse_data
+#include "parser_common.h"
+#undef OVS_LOAD_BYTES
+#undef OVS_SK_BUFF
+#undef PARSE_DATA
 
-enum ErrorCode {
-    ovs_no_error,
-    ovs_index_out_of_bounds,
-    ovs_out_of_packet,
-    ovs_header_too_long,
-    ovs_header_too_short,
-    ovs_unhandled_select,
-    ovs_checksum,
-    ovs_too_many_encap,
-    ovs_ipv6_disabled,
-};
-
-static bool ipv6_has_ext(u8 nw_proto) {
-    if ((nw_proto == IPPROTO_HOPOPTS) ||
-          (nw_proto == IPPROTO_ROUTING) ||
-          (nw_proto == IPPROTO_DSTOPTS) ||
-          (nw_proto == IPPROTO_AH) ||
-          (nw_proto == IPPROTO_FRAGMENT)) {
-            return true;
-    }
-    return false;
-}
-
+/* Program: tail-32 */
 __section_tail(PARSER_CALL)
 static int ovs_parser(struct __sk_buff* skb) {
-    void *data = (void *)(long)skb->data;
-    struct ebpf_headers_t hdrs = {};
+    struct ebpf_headers_t *hdrs;
     struct ebpf_metadata_t metadata = {};
     struct bpf_tunnel_key key;
-    struct ethhdr *eth;
-    ovs_be16 eth_proto;
     u32 ebpf_zero = 0;
-    int offset = 0;
-    u8 nw_proto = 0;
     int err = 0, ret = 0;
 
-    /* Verifier Check. */
-    if ((char *)data + sizeof(*eth) > (char *)(long)skb->data_end) {
-        printt("ERR parsing ethernet\n");
-        return TC_ACT_SHOT;
-    }
-
-    eth = data;
-    if (eth->h_proto == 0) {
-        printt("eth_proto == 0, return TC_ACT_OK\n");
-        return TC_ACT_OK;
-    }
-
-    printt("eth_proto = 0x%x len = %d\n", bpf_ntohs(eth->h_proto), skb->len);
+    printt("=== enter tc ingress ===\n");
     printt("skb->protocol = 0x%x\n", skb->protocol);
     printt("skb->ingress_ifindex %d skb->ifindex %d\n",
            skb->ingress_ifindex, skb->ifindex);
 
-    /* Link Layer. */
-    if (skb_load_bytes(skb, offset, &hdrs.ethernet, sizeof(hdrs.ethernet)) < 0) {
-        err = ovs_header_too_short;
-        printt("ERR: load byte %d\n", __LINE__);
-        goto end;
+    hdrs = bpf_get_headers();
+    if (!hdrs) {
+        printt("XDP does not parse the packet data,"\
+               "start full parsing\n");
+
+        err = tc_parse_data(skb); /* bpf/parser_common.h */
+        if (err) {
+            return TC_ACT_OK;
+        }
+        hdrs = bpf_get_headers();
     }
-    offset += sizeof(hdrs.ethernet);
-    hdrs.valid |= ETHER_VALID;
+    if (!hdrs) /* need to check again */
+        return TC_ACT_OK;
 
     /* VLAN 8021Q (0x8100) or 8021AD (0x88a8) in metadata
      * note: vlan in metadata is always the outer vlan
      */
     if (skb->vlan_tci) {
-        hdrs.vlan.tci = skb->vlan_tci | VLAN_TAG_PRESENT; /* host byte order */
-        hdrs.vlan.etherType = skb->vlan_proto;
-        hdrs.valid |= VLAN_VALID;
+        hdrs->vlan.tci = skb->vlan_tci | VLAN_TAG_PRESENT; /* host byte order */
+        hdrs->vlan.etherType = skb->vlan_proto;
+        hdrs->valid |= VLAN_VALID;
 
-        printt("skb metadata: vlan proto 0x%x tci %x\n", bpf_ntohs(skb->vlan_proto), skb->vlan_tci);
+        printt("skb metadata: vlan proto 0x%x tci %x\n",
+               bpf_ntohs(skb->vlan_proto), skb->vlan_tci);
     }
 
-    eth_proto = eth->h_proto;
-
-    if (eth_proto == bpf_htons(ETH_P_8021Q)){
-
-        /* The inner, if exists, is VLAN 8021Q (0x8100) */
-        struct vlan_hdr { /* wired format */
-            ovs_be16 tci;
-            ovs_be16 ethertype;
-        } cvlan;
-
-        /* parse cvlan */
-        if (skb_load_bytes(skb, offset - 2, &cvlan, sizeof(cvlan)) < 0) {
-            err = ovs_header_too_short;
-            printt("ERR: load byte %d\n", __LINE__);
-            goto end;
-        }
-        offset += sizeof(hdrs.cvlan);
-        hdrs.valid |= CVLAN_VALID;
-
-        hdrs.cvlan.tci = bpf_ntohs(cvlan.tci);
-        hdrs.cvlan.etherType = cvlan.ethertype;
-
-        printt("vlan tci 0x%x ethertype 0x%x\n",
-               hdrs.cvlan.tci, bpf_ntohs(hdrs.cvlan.etherType));
-
-        skb_load_bytes(skb, offset - 2, &eth_proto, 2);
-        printt("eth_proto = 0x%x\n", bpf_ntohs(eth_proto));
-    }
-
-    /* Network Layer.
-     *   see key_extract() in net/openvswitch/flow.c */
-    if (eth_proto == bpf_htons(ETH_P_IP)) {
-        struct iphdr nh;
-
-        printt("parse ipv4\n");
-        if (skb_load_bytes(skb, offset, &nh, sizeof(nh)) < 0) {
-            err = ovs_header_too_short;
-            printt("ERR: load byte %d\n", __LINE__);
-            goto end;
-        }
-        offset += nh.ihl * 4;
-        hdrs.valid |= IPV4_VALID;
-
-        hdrs.ipv4.ttl = nh.ttl;                /* u8 */
-        hdrs.ipv4.tos = nh.tos;                /* u8 */
-        hdrs.ipv4.protocol = nh.protocol;     /* u8*/
-        hdrs.ipv4.srcAddr = nh.saddr;        /* be32 */
-        hdrs.ipv4.dstAddr = nh.daddr;        /* be32 */
-
-        nw_proto = hdrs.ipv4.protocol;
-        printt("next proto 0x%x\n", nw_proto);
-
-    } else if (eth_proto == bpf_htons(ETH_P_ARP) ||
-               eth_proto == bpf_htons(ETH_P_RARP)) {
-        struct arp_rarp_t *arp;
-
-        printt("parse arp/rarp\n");
-
-        /* the struct arp_rarp_t is wired format */
-        arp = &hdrs.arp;
-        if (skb_load_bytes(skb, offset, arp, sizeof(hdrs.arp)) < 0) {
-            err = ovs_header_too_short;
-            printt("ERR: load byte %d\n", __LINE__);
-            goto end;
-        }
-        offset += sizeof(hdrs.arp);
-        hdrs.valid |= ARP_VALID;
-
-        if (arp->ar_hrd == bpf_htons(ARPHRD_ETHER) &&
-            arp->ar_pro == bpf_htons(ETH_P_IP) &&
-            arp->ar_hln == ETH_ALEN &&
-            arp->ar_pln == 4) {
-            printt("valid arp\n");
-        } else {
-            printt("ERR: invalid arp\n");
-        }
-        goto parse_metadata;
-
-    } else if (eth_proto == bpf_htons(ETH_P_IPV6)) {
-
-        struct ipv6hdr ip6hdr;    /* wired format */
-
-        if (skb_load_bytes(skb, offset, &ip6hdr, sizeof(ip6hdr)) < 0) {
-            err = ovs_header_too_short;
-            printt("ERR: load byte %d\n", __LINE__);
-            goto end;
-        }
-        offset += sizeof(struct ipv6hdr); /* wired format */
-        hdrs.valid |= IPV6_VALID;
-
-        printt("parse ipv6\n");
-
-        memcpy(&hdrs.ipv6.flowLabel, &ip6hdr.flow_lbl, 4); //FIXME
-        memcpy(&hdrs.ipv6.srcAddr, &ip6hdr.saddr, 16);
-        memcpy(&hdrs.ipv6.dstAddr, &ip6hdr.daddr, 16);
-
-        nw_proto = ip6hdr.nexthdr;
-
-        if (ipv6_has_ext(nw_proto)) {
-            printt("WARN: ipv6 nexthdr %x does not supported\n", nw_proto);
-            // need to update offset
-        }
-
-        printt("next proto = %x\n", nw_proto);
-
-    } else {
-        printt("ERR: eth_proto %x not supported\n", bpf_ntohs(eth_proto));
-        return TC_ACT_OK;
-    }
-
-    /* Transport Layer.
-     *   Handle: TCP, UDP, ICMP
-     */
-    if (nw_proto == IPPROTO_TCP) {
-        struct tcphdr tcp;
-
-        if (skb_load_bytes(skb, offset, &tcp, sizeof(tcp)) < 0) {
-            err = ovs_header_too_short;
-            printt("ERR: load byte %d\n", __LINE__);
-            goto end;
-        }
-        hdrs.valid |= TCP_VALID;
-
-        hdrs.tcp.srcPort = tcp.source;
-        hdrs.tcp.dstPort = tcp.dest;
-        hdrs.tcp.flags = TCP_FLAGS_BE16(&tcp);
-
-        printt("parse tcp src %d dst %d\n", bpf_ntohs(tcp.source), bpf_ntohs(tcp.dest));
-
-    } else if (nw_proto == IPPROTO_UDP) {
-        struct udphdr udp;
-
-        if (skb_load_bytes(skb, offset, &udp, sizeof(udp)) < 0) {
-            err = ovs_header_too_short;
-            printt("ERR: load byte %d\n", __LINE__);
-            goto end;
-        }
-        hdrs.valid |= UDP_VALID;
-
-        hdrs.udp.srcPort = udp.source;
-        hdrs.udp.dstPort = udp.dest;
-
-        printt("parse udp src %d dst %d\n", bpf_ntohs(udp.source), bpf_ntohs(udp.dest));
-
-    } else if (nw_proto == IPPROTO_ICMP) {  /* ICMP v4 */
-        struct icmphdr icmp;
-
-        if (skb_load_bytes(skb, offset, &icmp, sizeof(icmp)) < 0) {
-            err = ovs_header_too_short;
-            printt("ERR: load byte %d\n", __LINE__);
-            goto end;
-        }
-        hdrs.valid |= ICMP_VALID;
-
-        hdrs.icmp.type = icmp.type;
-        hdrs.icmp.code = icmp.code;
-
-        printt("parse icmp type %d code %d\n", icmp.type, icmp.code);
-
-    } else if (nw_proto == 0x3a /*EXTHDR_ICMP*/) {    /* ICMP v6 */
-        struct icmphdr icmp;
-
-        if (skb_load_bytes(skb, offset, &icmp, sizeof(icmp)) < 0) {
-            err = ovs_header_too_short;
-            printt("ERR: load byte %d\n", __LINE__);
-            goto end;
-        }
-        hdrs.valid |= ICMPV6_VALID;
-
-        hdrs.icmpv6.type = icmp.type;
-        hdrs.icmpv6.code = icmp.code;
-
-        printt("parse icmp v6 type %d code %d\n", icmp.type, icmp.code);
-    } else if (nw_proto == IPPROTO_GRE) {
-        printt("receive gre packet\n");
-    } else {
-        printt("WARN: nw_proto 0x%x not parsed\n", nw_proto);
-        /* Continue */
-    }
-
-parse_metadata:
     metadata.md.skb_priority = skb->priority;
 
     /* Don't use ovs_cb_get_ifindex(), that gets optimized into something
@@ -329,17 +122,12 @@ parse_metadata:
         printt("bpf_skb_get_tunnel_opt ret = %d\n", ret);
     }
 
-end:
     if (err != ovs_no_error) {
         printt("parse error: %d, drop\n", err);
         return TC_ACT_SHOT;
     }
 
     /* write flow key and md to key map */
-    printt("Parser: updating flow key\n");
-    bpf_map_update_elem(&percpu_headers,
-                        &ebpf_zero, &hdrs, BPF_ANY);
-
     if (ovs_cb_is_initial_parse(skb)) {
         bpf_map_update_elem(&percpu_metadata,
                             &ebpf_zero, &metadata, BPF_ANY);
@@ -350,6 +138,6 @@ end:
     printt("tail call match + lookup stage\n");
     bpf_tail_call(skb, &tailcalls, MATCH_ACTION_CALL);
 
-    printt("[ERROR] missing tail call\n");
+    printt("ERR: missing tail call\n");
     return TC_ACT_OK;
 }

--- a/bpf/parser_common.h
+++ b/bpf/parser_common.h
@@ -1,0 +1,265 @@
+/*
+ * Copyright (c) 2018 Nicira, Inc.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of version 2 of the GNU General Public
+ * License as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA
+ */
+#include "api.h"
+#include "helpers.h"
+
+#include <linux/if_ether.h>
+#include <linux/if_arp.h>
+#include <linux/if_vlan.h>
+#include <linux/ip.h>
+#include <linux/ipv6.h>
+#include <linux/tcp.h>
+#include <linux/udp.h>
+#include <linux/icmp.h>
+
+#define TCP_FLAGS_BE16(tp) (*(__be16 *)&tcp_flag_word(tp) & bpf_htons(0x0FFF))
+
+#ifndef ErrorCode
+#define ErrorCode
+enum ErrorCode {
+    ovs_no_error,
+    ovs_index_out_of_bounds,
+    ovs_out_of_packet,
+    ovs_header_too_long,
+    ovs_header_too_short,
+    ovs_unhandled_select,
+    ovs_checksum,
+    ovs_too_many_encap,
+    ovs_ipv6_disabled,
+};
+#endif
+
+/* Parse packet data: used both in TC and XDP
+ * Save result in map: percpu_headers
+ */
+static inline int
+PARSE_DATA(struct OVS_SK_BUFF *skb)
+{
+    struct ebpf_headers_t hdrs = {};
+    ovs_be16 eth_proto;
+    u32 ebpf_zero = 0;
+    int offset = 0;
+    u8 nw_proto = 0;
+    int err = 0;
+
+    /* Link Layer. */
+    if (OVS_LOAD_BYTES(skb, offset, &hdrs.ethernet, sizeof(hdrs.ethernet)) < 0) {
+        err = ovs_header_too_short;
+        printt("ERR: load byte %d\n", __LINE__);
+        goto end;
+    }
+    if (hdrs.ethernet.etherType == 0) {
+        printt("Layer 3 packet with eth_proto == 0, return TC_ACT_OK\n");
+        return TC_ACT_OK;
+    }
+
+    offset += sizeof(hdrs.ethernet);
+    hdrs.valid |= ETHER_VALID;
+
+    eth_proto = hdrs.ethernet.etherType;
+
+    if (eth_proto == bpf_htons(ETH_P_8021Q)){
+
+        /* The inner vlan, if exists, is VLAN 8021Q (0x8100)
+         * The outer vlan is at skb metadata, could be 8021Q or 8021AD
+         */
+        struct vlan_hdr { /* wired format */
+            ovs_be16 tci;
+            ovs_be16 ethertype;
+        } cvlan;
+
+        /* parse cvlan */
+        if (OVS_LOAD_BYTES(skb, offset - 2, &cvlan, sizeof(cvlan)) < 0) {
+            err = ovs_header_too_short;
+            printt("ERR: load byte %d\n", __LINE__);
+            goto end;
+        }
+        offset += sizeof(hdrs.cvlan);
+        hdrs.valid |= CVLAN_VALID;
+
+        hdrs.cvlan.tci = bpf_ntohs(cvlan.tci);
+        hdrs.cvlan.etherType = cvlan.ethertype;
+
+        printt("vlan tci 0x%x ethertype 0x%x\n",
+               hdrs.cvlan.tci, bpf_ntohs(hdrs.cvlan.etherType));
+
+        OVS_LOAD_BYTES(skb, offset - 2, &eth_proto, 2);
+        printt("eth_proto = 0x%x\n", bpf_ntohs(eth_proto));
+    }
+
+    /* Network Layer.
+     *   see key_extract() in net/openvswitch/flow.c */
+    if (eth_proto == bpf_htons(ETH_P_IP)) {
+        struct iphdr nh;
+
+        printt("parse ipv4\n");
+        if (OVS_LOAD_BYTES(skb, offset, &nh, sizeof(nh)) < 0) {
+            err = ovs_header_too_short;
+            printt("ERR: load byte %d\n", __LINE__);
+            goto end;
+        }
+        offset += nh.ihl * 4;
+        hdrs.valid |= IPV4_VALID;
+
+        hdrs.ipv4.ttl = nh.ttl;                /* u8 */
+        hdrs.ipv4.tos = nh.tos;                /* u8 */
+        hdrs.ipv4.protocol = nh.protocol;     /* u8*/
+        hdrs.ipv4.srcAddr = nh.saddr;        /* be32 */
+        hdrs.ipv4.dstAddr = nh.daddr;        /* be32 */
+
+        nw_proto = hdrs.ipv4.protocol;
+        printt("next proto 0x%x\n", nw_proto);
+
+    } else if (eth_proto == bpf_htons(ETH_P_ARP) ||
+               eth_proto == bpf_htons(ETH_P_RARP)) {
+        struct arp_rarp_t *arp;
+
+        printt("parse arp/rarp\n");
+
+        /* the struct arp_rarp_t is wired format */
+        arp = &hdrs.arp;
+        if (OVS_LOAD_BYTES(skb, offset, arp, sizeof(hdrs.arp)) < 0) {
+            err = ovs_header_too_short;
+            printt("ERR: load byte %d\n", __LINE__);
+            goto end;
+        }
+        offset += sizeof(hdrs.arp);
+        hdrs.valid |= ARP_VALID;
+
+        if (arp->ar_hrd == bpf_htons(ARPHRD_ETHER) &&
+            arp->ar_pro == bpf_htons(ETH_P_IP) &&
+            arp->ar_hln == ETH_ALEN &&
+            arp->ar_pln == 4) {
+            printt("valid arp\n");
+        } else {
+            printt("ERR: invalid arp\n");
+        }
+        goto end;
+
+    } else if (eth_proto == bpf_htons(ETH_P_IPV6)) {
+
+        struct ipv6hdr ip6hdr;    /* wired format */
+
+        if (OVS_LOAD_BYTES(skb, offset, &ip6hdr, sizeof(ip6hdr)) < 0) {
+            err = ovs_header_too_short;
+            printt("ERR: load byte %d\n", __LINE__);
+            goto end;
+        }
+        offset += sizeof(struct ipv6hdr); /* wired format */
+        hdrs.valid |= IPV6_VALID;
+
+        printt("parse ipv6\n");
+
+        memcpy(&hdrs.ipv6.flowLabel, &ip6hdr.flow_lbl, 4); //FIXME
+        memcpy(&hdrs.ipv6.srcAddr, &ip6hdr.saddr, 16);
+        memcpy(&hdrs.ipv6.dstAddr, &ip6hdr.daddr, 16);
+
+        nw_proto = ip6hdr.nexthdr;
+
+        if ((nw_proto == IPPROTO_HOPOPTS) ||
+            (nw_proto == IPPROTO_ROUTING) ||
+            (nw_proto == IPPROTO_DSTOPTS) ||
+            (nw_proto == IPPROTO_AH) ||
+            (nw_proto == IPPROTO_FRAGMENT)) {
+            printt("WARN: ipv6 nexthdr %x does not supported\n", nw_proto);
+        }
+
+        printt("next proto = %x\n", nw_proto);
+
+    } else {
+        printt("ERR: eth_proto %x not supported\n", bpf_ntohs(eth_proto));
+        return TC_ACT_OK;
+    }
+
+    /* Transport Layer.
+     *   Handle: TCP, UDP, ICMP
+     */
+    if (nw_proto == IPPROTO_TCP) {
+        struct tcphdr tcp;
+
+        if (OVS_LOAD_BYTES(skb, offset, &tcp, sizeof(tcp)) < 0) {
+            err = ovs_header_too_short;
+            printt("ERR: load byte %d\n", __LINE__);
+            goto end;
+        }
+        hdrs.valid |= TCP_VALID;
+
+        hdrs.tcp.srcPort = tcp.source;
+        hdrs.tcp.dstPort = tcp.dest;
+        hdrs.tcp.flags = TCP_FLAGS_BE16(&tcp);
+
+        printt("parse tcp src %d dst %d\n", bpf_ntohs(tcp.source), bpf_ntohs(tcp.dest));
+
+    } else if (nw_proto == IPPROTO_UDP) {
+        struct udphdr udp;
+
+        if (OVS_LOAD_BYTES(skb, offset, &udp, sizeof(udp)) < 0) {
+            err = ovs_header_too_short;
+            printt("ERR: load byte %d\n", __LINE__);
+            goto end;
+        }
+        hdrs.valid |= UDP_VALID;
+
+        hdrs.udp.srcPort = udp.source;
+        hdrs.udp.dstPort = udp.dest;
+
+        printt("parse udp src %d dst %d\n", bpf_ntohs(udp.source), bpf_ntohs(udp.dest));
+
+    } else if (nw_proto == IPPROTO_ICMP) {  /* ICMP v4 */
+        struct icmphdr icmp;
+
+        if (OVS_LOAD_BYTES(skb, offset, &icmp, sizeof(icmp)) < 0) {
+            err = ovs_header_too_short;
+            printt("ERR: load byte %d\n", __LINE__);
+            goto end;
+        }
+        hdrs.valid |= ICMP_VALID;
+
+        hdrs.icmp.type = icmp.type;
+        hdrs.icmp.code = icmp.code;
+
+        printt("parse icmp type %d code %d\n", icmp.type, icmp.code);
+
+    } else if (nw_proto == 0x3a /*EXTHDR_ICMP*/) {    /* ICMP v6 */
+        struct icmphdr icmp;
+
+        if (OVS_LOAD_BYTES(skb, offset, &icmp, sizeof(icmp)) < 0) {
+            err = ovs_header_too_short;
+            printt("ERR: load byte %d\n", __LINE__);
+            goto end;
+        }
+        hdrs.valid |= ICMPV6_VALID;
+
+        hdrs.icmpv6.type = icmp.type;
+        hdrs.icmpv6.code = icmp.code;
+
+        printt("parse icmp v6 type %d code %d\n", icmp.type, icmp.code);
+    } else if (nw_proto == IPPROTO_GRE) {
+        printt("receive gre packet\n");
+    } else {
+        printt("WARN: nw_proto 0x%x not parsed\n", nw_proto);
+        /* Continue */
+    }
+
+    /* write flow key and md to key map */
+    printt("Parser: updating flow key\n");
+    bpf_map_update_elem(&percpu_headers,
+                        &ebpf_zero, &hdrs, BPF_ANY);
+end:
+    return 0;
+}


### PR DESCRIPTION
```
  1: datapath - basic BPF commands                   ok
  2: datapath - ping between two ports               ok
  3: datapath - http between two ports               ok
  4: datapath - ping between two ports on vlan       ok
  5: datapath - ping between two ports on cvlan      ok
  6: datapath - ping6 between two ports              ok
  7: datapath - ping6 between two ports on vlan      ok
  8: datapath - ping6 between two ports on cvlan     ok
  9: datapath - ping over bond                       skipped (system-bpf-traffic.at:210)
 10: datapath - ping over vxlan tunnel               ok
 11: datapath - ping over vxlan6 tunnel              ok
 12: datapath - ping over gre tunnel                 ok
 13: datapath - ping over geneve tunnel              ok
 14: datapath - ping over geneve tunnel with TLV     ok
 15: datapath - ping over geneve6 tunnel             ok
 16: datapath - clone action                         FAILED (system-bpf-traffic.at:487)
 17: datapath - mpls actions                         FAILED (system-bpf-traffic.at:526)
 18: datapath - basic truncate action                FAILED (system-bpf-traffic.at:586)
 19: datapath - truncate and output to gre tunnel    FAILED (system-bpf-traffic.at:720)
 20: ovn -- 1 LR connects 2 LSes                     ok

```